### PR TITLE
Fixed magic joint number in model utils

### DIFF
--- a/src/lib/detectors/multi_pose.py
+++ b/src/lib/detectors/multi_pose.py
@@ -41,10 +41,11 @@ class MultiPoseDetector(BaseDetector):
       forward_time = time.time()
       
       if self.opt.flip_test:
+        num_joints = self.opt.heads["hm_hp"]
         output['hm'] = (output['hm'][0:1] + flip_tensor(output['hm'][1:2])) / 2
         output['wh'] = (output['wh'][0:1] + flip_tensor(output['wh'][1:2])) / 2
         output['hps'] = (output['hps'][0:1] + 
-          flip_lr_off(output['hps'][1:2], self.flip_idx)) / 2
+          flip_lr_off(output['hps'][1:2], self.flip_idx, num_joints)) / 2
         hm_hp = (hm_hp[0:1] + flip_lr(hm_hp[1:2], self.flip_idx)) / 2 \
                 if hm_hp is not None else None
         reg = reg[0:1] if reg is not None else None

--- a/src/lib/models/decode.py
+++ b/src/lib/models/decode.py
@@ -282,7 +282,7 @@ def single_pose_decode(
         hm_score, hm_inds, hm_ys, hm_xs = _topk_channel_with_reg_kps(hm_hp, reg_kps, K=K) # b x J x K
 
         hp_offset = _transpose_and_gather_feat_plus(
-            hp_offset, hm_inds.view(batch, -1))
+            hp_offset, hm_inds.view(batch, -1), num_joints)
         hp_offset = hp_offset.view(batch, num_joints, K, 2)
         hm_xs = hm_xs + hp_offset[:, :, :, 0]
         hm_ys = hm_ys + hp_offset[:, :, :, 1]

--- a/src/lib/models/losses.py
+++ b/src/lib/models/losses.py
@@ -141,7 +141,7 @@ class RegL1Loss(nn.Module):
     super(RegL1Loss, self).__init__()
   
   def forward(self, output, mask, ind, target):
-    pred = _transpose_and_gather_feat_plus(output, ind)
+    pred = _transpose_and_gather_feat_plus(output, ind, num_joints)
     mask = mask.unsqueeze(2).expand_as(pred).float()
     # loss = F.l1_loss(pred * mask, target * mask, reduction='elementwise_mean')
     loss = F.l1_loss(pred * mask, target * mask, size_average=False)

--- a/src/lib/models/losses.py
+++ b/src/lib/models/losses.py
@@ -141,6 +141,7 @@ class RegL1Loss(nn.Module):
     super(RegL1Loss, self).__init__()
   
   def forward(self, output, mask, ind, target):
+    num_joints = output.shape[1] // 2
     pred = _transpose_and_gather_feat_plus(output, ind, num_joints)
     mask = mask.unsqueeze(2).expand_as(pred).float()
     # loss = F.l1_loss(pred * mask, target * mask, reduction='elementwise_mean')

--- a/src/lib/models/utils.py
+++ b/src/lib/models/utils.py
@@ -22,9 +22,9 @@ def _gather_feat(feat, ind, mask=None):
     return feat
 
 
-def _gather_feat_plus(feat, ind):
+def _gather_feat_plus(feat, ind, num_joints):
     # num_objs = ind.size(1) / 17
-    ind = ind.view(ind.size(0), -1, 17)
+    ind = ind.view(ind.size(0), -1, num_joints)
     ind = ind.unsqueeze(3).expand(ind.size(0), ind.size(1), ind.size(2), 2)
     feat = feat.gather(1, ind)
     return feat
@@ -36,10 +36,10 @@ def _transpose_and_gather_feat(feat, ind):
     feat = _gather_feat(feat, ind)
     return feat
 
-def _transpose_and_gather_feat_plus(feat, ind):
+def _transpose_and_gather_feat_plus(feat, ind, num_joints):
     feat = feat.permute(0, 2, 3, 1).contiguous()
-    feat = feat.view(feat.size(0), -1, 17, 2)
-    feat = _gather_feat_plus(feat, ind)
+    feat = feat.view(feat.size(0), -1, num_joints, 2)
+    feat = _gather_feat_plus(feat, ind, num_joints)
     feat = feat.view(feat.size(0), -1, 2)
     return feat
 
@@ -59,10 +59,10 @@ def flip_lr(x, flip_idx):
     return torch.from_numpy(tmp.reshape(shape)).to(x.device)
 
 
-def flip_lr_off(x, flip_idx):
+def flip_lr_off(x, flip_idx, num_joints):
     tmp = x.detach().cpu().numpy()[..., ::-1].copy()
     shape = tmp.shape
-    tmp = tmp.reshape(tmp.shape[0], 17, 2,
+    tmp = tmp.reshape(tmp.shape[0], num_joints, 2,
                       tmp.shape[2], tmp.shape[3])
     tmp[:, :, 0, :, :] *= -1
     for e in flip_idx:

--- a/src/lib/utils/debugger.py
+++ b/src/lib/utils/debugger.py
@@ -45,6 +45,22 @@ class Debugger(object):
                               (255, 0, 0), (0, 0, 255), (255, 0, 0), (0, 0, 255),
                               (255, 0, 0), (0, 0, 255)]
 
+        if dataset in ['active_hand']:
+            self.names = ['h']
+            self.num_class = 1
+            self.num_joints = 6
+            self.edges = [[0, 1], [0, 2], [0, 3], [0, 4], [0, 5]]
+            self.ec = [(255, 0, 0), (0, 0, 255), (255, 0, 0), (0, 0, 255),
+                       (255, 0, 0), (0, 0, 255), (255, 0, 255),
+                       (255, 0, 0), (255, 0, 0), (0, 0, 255), (0, 0, 255),
+                       (255, 0, 0), (0, 0, 255), (255, 0, 255),
+                       (255, 0, 0), (255, 0, 0), (0, 0, 255), (0, 0, 255)]
+            self.colors_hp = [(255, 0, 255), (255, 0, 0), (0, 0, 255),
+                              (255, 0, 0), (0, 0, 255), (255, 0, 0), (0, 0, 255),
+                              (255, 0, 0), (0, 0, 255), (255, 0, 0), (0, 0, 255),
+                              (255, 0, 0), (0, 0, 255), (255, 0, 0), (0, 0, 255),
+                              (255, 0, 0), (0, 0, 255)]
+
         num_classes = len(self.names)
         self.down_ratio = down_ratio
 
@@ -125,7 +141,10 @@ class Debugger(object):
     # from movenet-pytorch
     def get_adjacent_keypoints(self, keypoint_scores, keypoint_coords, min_confidence=0.1):
         results = []
-        for left, right in CONNECTED_PART_INDICES:
+        for left, right in self.edges:
+            if left >= self.num_joints or right >= self.num_joints:
+                continue
+
             if keypoint_scores[left] < min_confidence or keypoint_scores[right] < min_confidence:
                 continue
             results.append(


### PR DESCRIPTION
The [model/utils.py](https://github.com/lee-man/movenet/blob/main/src/lib/models/utils.py#L27) file contains static methods which use magic numbers for the joint count (`17`). If another joint count is defined for example in `opt.heads` this will lead to an exception.

I have updated the methods to take a third parameter for the joint count and adapted all method calls accordingly. Most of the time I tried to use the `num_joints` variable, except for the `MultiPoseDetector` where I had to use the `opt.heads["hm_hp"]` which should be similar to the joint count.